### PR TITLE
don't try to start containers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,5 +33,3 @@ beacon_node_restart_window_sec: 120
 
 # general container management
 compose_recreate: false
-compose_restart: false
-compose_destroy: false

--- a/tasks/compose.yml
+++ b/tasks/compose.yml
@@ -34,6 +34,10 @@
             - '{{ beacon_node_listening_port }}:{{ beacon_node_listening_port }}/tcp'
             - '{{ beacon_node_discovery_port }}:{{ beacon_node_discovery_port }}/udp'
           command:
+            {% if beacon_node_network == "testnet2" %}
+            - '--run'
+            - '--'
+            {% endif %}
             - '--nat=extip:{{ beacon_node_public_address }}'
             - '--log-level={{ beacon_node_log_level }}'
             - '--tcp-port={{ beacon_node_listening_port }}'

--- a/tasks/container.yml
+++ b/tasks/container.yml
@@ -19,19 +19,8 @@
       {% if compose_recreate %}
       --force-recreate \
       {% endif %}
-      --no-color
+      --no-color \
+      --no-start
   args:
     chdir: '{{ beacon_node_cont_vol }}'
-  when: compose_state == "present"
 
-- name: 'Restart container: {{ beacon_node_cont_name }}'
-  command: docker-compose --compatibility down
-  args:
-    chdir: '{{ beacon_node_cont_vol }}'
-  when: compose_restart
-
-- name: 'Destroy container: {{ beacon_node_cont_name }}'
-  command: docker-compose --compatibility down
-  args:
-    chdir: '{{ beacon_node_cont_vol }}'
-  when: compose_destroy


### PR DESCRIPTION
and remove some unused commands/variables.

The rationale is that these containers need validator keys uploaded to
them before they can start and this is managed elsewhere.