### PR TITLE
syntax and CLI fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,9 +20,7 @@ beacon_node_metrics_port: 9200
 beacon_node_rpc_port: 9900
 
 # resource limits, mem in MB
-beacon_node_cpu_limit: 0.80
 beacon_node_mem_limit: '{{ (ansible_memtotal_mb * 0.6) | int }}'
-beacon_node_cpu_reserve: 0.40
 beacon_node_mem_reserve: '{{ (ansible_memtotal_mb * 0.4) | int }}'
 
 # container restart policy

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,3 +31,7 @@ beacon_node_restart_window_sec: 120
 
 # general container management
 compose_recreate: false
+
+# shared testnet cron job
+beacon_node_shared_testnet_cron: false
+

--- a/tasks/compose.yml
+++ b/tasks/compose.yml
@@ -33,7 +33,7 @@
             - '{{ beacon_node_metrics_port }}:{{ beacon_node_metrics_port }}/tcp'
             - '{{ beacon_node_listening_port }}:{{ beacon_node_listening_port }}/tcp'
             - '{{ beacon_node_discovery_port }}:{{ beacon_node_discovery_port }}/udp'
-          command:
+          command: |
             {% if beacon_node_network == "testnet2" %}
             - '--run'
             - '--'

--- a/tasks/compose.yml
+++ b/tasks/compose.yml
@@ -31,20 +31,20 @@
             - '{{ beacon_node_metrics_port }}:{{ beacon_node_metrics_port }}/tcp'
             - '{{ beacon_node_listening_port }}:{{ beacon_node_listening_port }}/tcp'
             - '{{ beacon_node_discovery_port }}:{{ beacon_node_discovery_port }}/udp'
-          command: |
+          command: >-
             {% if beacon_node_network == "testnet2" %}
-            --run \
-            -- \
+            --run
+            --
             {% endif %}
-            --nat=extip:{{ beacon_node_public_address }} \
-            --log-level={{ beacon_node_log_level }} \
-            --tcp-port={{ beacon_node_listening_port }} \
-            --udp-port={{ beacon_node_discovery_port }} \
-            --rpc \
-            --rpc-address=0.0.0.0 \
-            --rpc-port={{ beacon_node_rpc_port }} \
-            --metrics \
-            --metrics-address=0.0.0.0 \
+            --nat=extip:{{ beacon_node_public_address }}
+            --log-level={{ beacon_node_log_level }}
+            --tcp-port={{ beacon_node_listening_port }}
+            --udp-port={{ beacon_node_discovery_port }}
+            --rpc
+            --rpc-address=0.0.0.0
+            --rpc-port={{ beacon_node_rpc_port }}
+            --metrics
+            --metrics-address=0.0.0.0
             --metrics-port={{ beacon_node_metrics_port }}
           volumes:
             - '{{ beacon_node_cont_vol }}/data:/root/.cache/nimbus'

--- a/tasks/compose.yml
+++ b/tasks/compose.yml
@@ -35,18 +35,18 @@
             - '{{ beacon_node_discovery_port }}:{{ beacon_node_discovery_port }}/udp'
           command: |
             {% if beacon_node_network == "testnet2" %}
-            - '--run'
-            - '--'
+            --run \
+            -- \
             {% endif %}
-            - '--nat=extip:{{ beacon_node_public_address }}'
-            - '--log-level={{ beacon_node_log_level }}'
-            - '--tcp-port={{ beacon_node_listening_port }}'
-            - '--udp-port={{ beacon_node_discovery_port }}'
-            - '--rpc'
-            - '--rpc-address=0.0.0.0'
-            - '--rpc-port={{ beacon_node_rpc_port }}'
-            - '--metrics'
-            - '--metrics-address=0.0.0.0'
-            - '--metrics-port={{ beacon_node_metrics_port }}'
+            --nat=extip:{{ beacon_node_public_address }} \
+            --log-level={{ beacon_node_log_level }} \
+            --tcp-port={{ beacon_node_listening_port }} \
+            --udp-port={{ beacon_node_discovery_port }} \
+            --rpc \
+            --rpc-address=0.0.0.0 \
+            --rpc-port={{ beacon_node_rpc_port }} \
+            --metrics \
+            --metrics-address=0.0.0.0 \
+            --metrics-port={{ beacon_node_metrics_port }}
           volumes:
             - '{{ beacon_node_cont_vol }}/data:/root/.cache/nimbus'

--- a/tasks/compose.yml
+++ b/tasks/compose.yml
@@ -18,10 +18,8 @@
           deploy:
             resources:
               limits:
-                cpus: '{{ beacon_node_cpu_limit | string }}'
                 memory: '{{ beacon_node_mem_limit }}M'
               reservations:
-                cpus: '{{ beacon_node_cpu_reserve | string }}'
                 memory: '{{ beacon_node_mem_reserve }}M'
             restart_policy:
               condition: '{{ beacon_node_restart_ondition }}'

--- a/tasks/container.yml
+++ b/tasks/container.yml
@@ -15,7 +15,6 @@
       up \
       --quiet-pull \
       --no-build \
-      --detach \
       {% if compose_recreate %}
       --force-recreate \
       {% endif %}

--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -1,0 +1,11 @@
+---
+# "cron.name" should not be changed, or a new cron job will be created for the new name,
+# in addition to the old one.
+- name: "Shared testnet: periodic container restart Cron job"
+  cron:
+    name: "shared testnet restart"
+    minute: "10"
+    hour: "0,6,12,18"
+    job: "PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin'; cd {{ beacon_node_cont_vol }}; docker-compose --compatibility run --rm --name {{ beacon_node_cont_name }}-build-run beacon_node --build; docker-compose restart -t 60"
+  when: beacon_node_shared_testnet_cron
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,5 +2,6 @@
 - import_tasks: install.yml
 - import_tasks: compose.yml
 - import_tasks: container.yml
+- import_tasks: cron.yml
 - import_tasks: firewall.yml
 - import_tasks: consul.yml


### PR DESCRIPTION
There's some weirdness in the interaction between Jinja2 directives and
YAML syntax.

Also, `--detach` cannot be used with `--no-start` for docker-compose.