### PR TITLE
put container restarts under the "cont_restart" flag

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ beacon_node_mem_limit: '{{ (ansible_memtotal_mb * 0.6) | int }}'
 beacon_node_mem_reserve: '{{ (ansible_memtotal_mb * 0.4) | int }}'
 
 # container restart policy
-beacon_node_restart_ondition: 'on-failure'
+beacon_node_restart_condition: 'on-failure'
 beacon_node_restart_max_attempts: 3
 beacon_node_restart_delay_sec: 10
 beacon_node_restart_window_sec: 120

--- a/tasks/compose.yml
+++ b/tasks/compose.yml
@@ -22,7 +22,7 @@
               reservations:
                 memory: '{{ beacon_node_mem_reserve }}M'
             restart_policy:
-              condition: '{{ beacon_node_restart_ondition }}'
+              condition: '{{ beacon_node_restart_condition }}'
               max_attempts: '{{ beacon_node_restart_max_attempts }}'
               delay: '{{ beacon_node_restart_delay_sec }}s'
               window: '{{ beacon_node_restart_window_sec }}s'

--- a/tasks/container.yml
+++ b/tasks/container.yml
@@ -9,17 +9,18 @@
 
 # --compatibility flag required for mem/cpu limits
 - name: 'Create container: {{ beacon_node_cont_name }}'
-  command: |
-    docker-compose \
-      --compatibility \
-      up \
-      --quiet-pull \
-      --no-build \
+  command: >-
+    docker-compose
+      --compatibility
+      up
+      --quiet-pull
+      --no-build
       {% if compose_recreate %}
-      --force-recreate \
+      --force-recreate
       {% endif %}
-      --no-color \
-      --no-start
+      --no-color
+      -d
   args:
     chdir: '{{ beacon_node_cont_vol }}'
+  when: cont_restart
 


### PR DESCRIPTION
Had to give up on `docker-compose up --no-start` because it still
stopped the running container image before pulling and creating a new
one.

Further more, we can now handle containers being restarted automatically
on our Altona servers.