### PR TITLE
add beacon_node_*_light_client_data variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,10 @@ beacon_node_rest_enabled: true
 beacon_node_rest_address: '127.0.0.1'
 beacon_node_rest_port: 5052
 
+# Serving light client data
+beacon_node_serve_light_client_data: false
+beacon_node_import_light_client_data: 'none'
+
 # resource limits, mem in MB
 beacon_node_mem_limit: '{{ (ansible_memtotal_mb * 0.5) | int }}'
 beacon_node_mem_reserve: '{{ (ansible_memtotal_mb * 0.4) | int }}'

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -58,4 +58,6 @@ services:
       --metrics-address=0.0.0.0
       --metrics-port={{ beacon_node_metrics_port }}
 {% endif %}
+      --serve-light-client-data={{ beacon_node_serve_light_client_data | to_json }}
+      --import-light-client-data={{ beacon_node_import_light_client_data }}
 


### PR DESCRIPTION
To control the `--serve-light-client-data` and
`--import-light-client-data` flags.

Note: These new flags are only available on `unstable` at this time. `stable` does not support them yet.